### PR TITLE
reload scenes after update if necessary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ cdk.out
 
 # Parcel default cache directory
 .parcel-cache
+
+# Intellij Idea
+.idea

--- a/sendmessage/app.js
+++ b/sendmessage/app.js
@@ -393,7 +393,28 @@ async function update_scene(event){
        sceneId: recvMessage.data.id
     }
   }).promise());
-  
+
+  const switch_dm = recvMessage.data.id === recvMessage.sceneId;
+  if (switch_dm) {
+    promises.push(switch_scene({
+      campaignId: recvMessage.campaignId,
+      data: {
+        sceneId: recvMessage.data.id,
+        switch_dm: true
+      }
+    }));
+  }
+
+  const switch_players = recvMessage.data.id === recvMessage.playersSceneId;
+  if (switch_players) {
+    promises.push(switch_scene({
+      campaignId: recvMessage.campaignId,
+      data: {
+        sceneId: recvMessage.data.id
+      }
+    }));
+  }
+
   return Promise.allSettled(promises);
 }
 


### PR DESCRIPTION
This is the cloud side solution for https://github.com/cyruzzo/AboveVTT/issues/421
The client side solution can be found here: https://github.com/cyruzzo/AboveVTT/pull/426

When a scene is updated, it is never refreshed locally. This PR changes that when necessary.


* If the dm is on the scene that was updated, this will send a `custom/myVTT/scene` to the DM.
* If the players are on the scene that was updated, this will send a `custom/myVTT/scene` to the players.
  * In order for the player side of this to work, we will need this merged https://github.com/cyruzzo/AboveVTT/pull/426